### PR TITLE
Update gen_commands.example.py

### DIFF
--- a/gen_commands.example.py
+++ b/gen_commands.example.py
@@ -152,7 +152,7 @@ def gen_comm(zstart, zend):
             cmd += ' --base_filename "{}"'.format(list2cmdline([file_name]))
         else:
             cmd += ' --base_path {}'.format(shlex.quote(data_directory))
-            cmd += ' --base_filename "{}"'.format(shlex.quote(file_name))
+            cmd += ' --base_filename {}'.format(shlex.quote(file_name))
         cmd += ' --extension {}'.format(file_format)
         cmd += ' --x_extent {d[0]} {d[1]}'.format(d=x_extent)
         cmd += ' --y_extent {d[0]} {d[1]}'.format(d=y_extent)


### PR DESCRIPTION
fixed issue where printed commands wouldn't work as a result of the double quotes for the base_filename on Ubuntu 16.04